### PR TITLE
Inline mode pass gesture

### DIFF
--- a/Demos/DemoControllers/MapDemo.swift
+++ b/Demos/DemoControllers/MapDemo.swift
@@ -14,17 +14,20 @@ class MapDemo: SimpleDemo {
     
     override class func openDemo(from parent: UIViewController, in view: UIView?) {
         let useInlineMode = view != nil
-        
+
         let controller = ColorDemo()
+
+        var options = SheetOptions(useInlineMode: useInlineMode)
+        options.shrinkPresentingViewController = !useInlineMode
         
         let sheet = SheetViewController(
             controller: controller,
             sizes: [.fixed(100), .percent(0.5), .fullscreen],
-            options: SheetOptions(useInlineMode: useInlineMode))
+            options: options)
         sheet.allowPullingPastMaxHeight = false
         sheet.allowPullingPastMinHeight = false
         
-        sheet.dismissOnPull = false
+        sheet.dismissOnPull = true
         sheet.dismissOnOverlayTap = false
         sheet.overlayColor = UIColor.clear
         
@@ -32,7 +35,7 @@ class MapDemo: SimpleDemo {
         sheet.contentViewController.view.layer.shadowOpacity = 0.1
         sheet.contentViewController.view.layer.shadowRadius = 10
         sheet.allowGestureThroughOverlay = true
-        
+
         addSheetEventLogging(to: sheet)
         
         if let view = view {

--- a/FittedSheets/SheetView.swift
+++ b/FittedSheets/SheetView.swift
@@ -12,10 +12,19 @@ import UIKit
 class SheetView: UIView {
 
     weak var delegate: SheetViewDelegate?
+    weak var viewToTranslateGesture: UIView?
 
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        return self.delegate?.sheetPoint(inside: point, with: event) ?? true
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+
+        if self.delegate?.sheetPoint(inside: point, with: event) ?? true {
+            return view
+        } else {
+            // Pass gesture to parentController 
+            return viewToTranslateGesture?.hitTest(point, with: event)
+        }
     }
+
 }
 
 #endif // os(iOS) || os(tvOS) || os(watchOS)

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -230,6 +230,10 @@ public class SheetViewController: UIViewController {
         self.updateOrderedSizes()
         self.contentViewController.updatePreferredHeight()
         self.resize(to: self.currentSize, animated: false)
+
+        if self.options.useInlineMode {
+            (self.view as? SheetView)?.viewToTranslateGesture = presentingViewController?.view
+        }
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
@@ -634,8 +638,8 @@ public class SheetViewController: UIViewController {
         
         self.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            self.view.topAnchor.constraint(equalTo: view.topAnchor),
-            self.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            self.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            self.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             self.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             self.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -55,6 +55,10 @@ public class SheetViewController: UIViewController {
         return self.contentViewController.childViewController
     }
 
+    /// If true ViewController in inlineMode whoold consider safeArea
+    /// can be used with TabBar
+    public var shouldConsiderSafeAreaInInlineMode: Bool = false
+
     public override var childForStatusBarStyle: UIViewController? {
         childViewController
     }
@@ -637,12 +641,21 @@ public class SheetViewController: UIViewController {
         self.didMove(toParent: parent)
         
         self.view.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            self.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            self.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            self.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            self.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
+        if #available(iOS 11.0, *), shouldConsiderSafeAreaInInlineMode {
+            NSLayoutConstraint.activate([
+                self.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                self.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+                self.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                self.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                self.view.topAnchor.constraint(equalTo: view.topAnchor),
+                self.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                self.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                self.view.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            ])
+        }
         self.animateIn(size: size, duration: duration, completion: completion)
     }
     

--- a/FittedSheets/SheetViewController.swift
+++ b/FittedSheets/SheetViewController.swift
@@ -618,6 +618,7 @@ public class SheetViewController: UIViewController {
                     self.view.removeFromSuperview()
                     self.removeFromParent()
                     self.didDismiss?(self)
+                    self.dismiss(animated: animated, completion: nil)
                 }
             } else {
                 self.dismiss(animated: animated, completion: nil)


### PR DESCRIPTION
**Issue**
There is a need to use inlineMode with ViewCntroller sheet presented modaly, and not like a childViewController.

**Result**
So now inlineMode can be possible as in documentation

`sheetController.animateIn(to: view, in: self) `

And also we can use

self.present(sheet, animated: false, completion: nil)

**Solution**
all gestures would be sent to presentingViewController.view if it exists

**Additional fix**
If we use inlineMode with sheetController.animateIn inside TabBarController we would want to consider safeArea